### PR TITLE
Experimental: EVMLogger fixed error code

### DIFF
--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1148,7 +1148,7 @@ func TestDeleteStorage(t *testing.T) {
 		addr     = common.HexToAddress("0x1")
 	)
 	// Initialize account and populate storage
-	state.SetBalance(addr, big.NewInt(1))
+	state.SetBalance(addr, big.NewInt(1), 0x0)
 	state.CreateAccount(addr)
 	for i := 0; i < 1000; i++ {
 		slot := common.Hash(uint256.NewInt(uint64(i)).Bytes32())

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"errors"
 	"fmt"
+	"math"
 )
 
 // List evm execution errors
@@ -71,3 +72,125 @@ type ErrInvalidOpCode struct {
 }
 
 func (e *ErrInvalidOpCode) Error() string { return fmt.Sprintf("invalid opcode: %s", e.opcode) }
+
+// rpcError is the same interface as the one defined in rpc/errors.go
+// but we do not want to depend on rpc package here so we redefine it.
+//
+// It's used to ensure that the VMError implements the RPC error interface.
+type rpcError interface {
+	Error() string  // returns the message
+	ErrorCode() int // returns the code
+}
+
+var _ rpcError = (*VMError)(nil)
+
+// VMError wraps a VM error with an additional stable error code. The error
+// field is the original error that caused the VM error and must be one of the
+// VM error defined at the top of this file.
+//
+// If the error is not one of the known error above, the error code will be
+// set to VMErrorCodeUnknown.
+type VMError struct {
+	error
+	code int
+}
+
+func VMErrorFromErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &VMError{
+		error: err,
+		code:  vmErrorCodeFromErr(err),
+	}
+}
+
+func (e *VMError) Error() string {
+	return e.error.Error()
+}
+
+func (e *VMError) Unwrap() error {
+	return errors.Unwrap(e.error)
+}
+
+func (e *VMError) ErrorCode() int {
+	return e.code
+}
+
+const (
+	// We start the error code at 1 so that we can use 0 later for some possible extension. There
+	// is no unspecified value for the code today because it should always be set to a valid value
+	// that could be VMErrorCodeUnknown if the error is not mapped to a known error code.
+
+	VMErrorCodeOutOfGas = 1 + iota
+	VMErrorCodeCodeStoreOutOfGas
+	VMErrorCodeDepth
+	VMErrorCodeInsufficientBalance
+	VMErrorCodeContractAddressCollision
+	VMErrorCodeExecutionReverted
+	VMErrorCodeMaxInitCodeSizeExceeded
+	VMErrorCodeMaxCodeSizeExceeded
+	VMErrorCodeInvalidJump
+	VMErrorCodeWriteProtection
+	VMErrorCodeReturnDataOutOfBounds
+	VMErrorCodeGasUintOverflow
+	VMErrorCodeInvalidCode
+	VMErrorCodeNonceUintOverflow
+	VMErrorCodeStackUnderflow
+	VMErrorCodeStackOverflow
+	VMErrorCodeInvalidOpCode
+
+	// VMErrorCodeUnknown explicitly marks an error as unknown, this is useful when error is converted
+	// from an actual `error` in which case if the mapping is not known, we can use this value to indicate that.
+	VMErrorCodeUnknown = math.MaxInt - 1
+)
+
+func vmErrorCodeFromErr(err error) int {
+	switch {
+	case errors.Is(err, ErrOutOfGas):
+		return VMErrorCodeOutOfGas
+	case errors.Is(err, ErrCodeStoreOutOfGas):
+		return VMErrorCodeCodeStoreOutOfGas
+	case errors.Is(err, ErrDepth):
+		return VMErrorCodeDepth
+	case errors.Is(err, ErrInsufficientBalance):
+		return VMErrorCodeInsufficientBalance
+	case errors.Is(err, ErrContractAddressCollision):
+		return VMErrorCodeContractAddressCollision
+	case errors.Is(err, ErrExecutionReverted):
+		return VMErrorCodeExecutionReverted
+	case errors.Is(err, ErrMaxInitCodeSizeExceeded):
+		return VMErrorCodeMaxInitCodeSizeExceeded
+	case errors.Is(err, ErrMaxCodeSizeExceeded):
+		return VMErrorCodeMaxCodeSizeExceeded
+	case errors.Is(err, ErrInvalidJump):
+		return VMErrorCodeInvalidJump
+	case errors.Is(err, ErrWriteProtection):
+		return VMErrorCodeWriteProtection
+	case errors.Is(err, ErrReturnDataOutOfBounds):
+		return VMErrorCodeReturnDataOutOfBounds
+	case errors.Is(err, ErrGasUintOverflow):
+		return VMErrorCodeGasUintOverflow
+	case errors.Is(err, ErrInvalidCode):
+		return VMErrorCodeInvalidCode
+	case errors.Is(err, ErrNonceUintOverflow):
+		return VMErrorCodeNonceUintOverflow
+
+	default:
+		// Dynamic errors
+		if v := (*ErrStackUnderflow)(nil); errors.As(err, &v) {
+			return VMErrorCodeStackUnderflow
+		}
+
+		if v := (*ErrStackOverflow)(nil); errors.As(err, &v) {
+			return VMErrorCodeStackOverflow
+		}
+
+		if v := (*ErrInvalidOpCode)(nil); errors.As(err, &v) {
+			return VMErrorCodeInvalidOpCode
+		}
+
+		return VMErrorCodeUnknown
+	}
+}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -534,8 +534,8 @@ func (evm *EVM) captureEnd(isRoot bool, typ OpCode, startGas uint64, leftOverGas
 	}
 
 	if isRoot {
-		tracer.CaptureEnd(ret, startGas-leftOverGas, err)
+		tracer.CaptureEnd(ret, startGas-leftOverGas, CallErrorFromErr(err))
 	} else {
-		tracer.CaptureExit(ret, startGas-leftOverGas, err)
+		tracer.CaptureExit(ret, startGas-leftOverGas, CallErrorFromErr(err))
 	}
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -534,8 +534,8 @@ func (evm *EVM) captureEnd(isRoot bool, typ OpCode, startGas uint64, leftOverGas
 	}
 
 	if isRoot {
-		tracer.CaptureEnd(ret, startGas-leftOverGas, CallErrorFromErr(err))
+		tracer.CaptureEnd(ret, startGas-leftOverGas, VMErrorFromErr(err))
 	} else {
-		tracer.CaptureExit(ret, startGas-leftOverGas, CallErrorFromErr(err))
+		tracer.CaptureExit(ret, startGas-leftOverGas, VMErrorFromErr(err))
 	}
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -158,9 +158,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		defer func() {
 			if err != nil {
 				if !logged {
-					in.evm.Config.Tracer.CaptureState(pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
+					in.evm.Config.Tracer.CaptureState(pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, CallErrorFromErr(err))
 				} else {
-					in.evm.Config.Tracer.CaptureFault(pcCopy, op, gasCopy, cost, callContext, in.evm.depth, err)
+					in.evm.Config.Tracer.CaptureFault(pcCopy, op, gasCopy, cost, callContext, in.evm.depth, CallErrorFromErr(err))
 				}
 			}
 		}()
@@ -219,7 +219,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			// Do tracing before memory expansion
 			if debug {
 				in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, GasChangeCallOpCode)
-				in.evm.Config.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
+				in.evm.Config.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, CallErrorFromErr(err))
 				logged = true
 			}
 			if memorySize > 0 {
@@ -227,7 +227,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			}
 		} else if debug {
 			in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, GasChangeCallOpCode)
-			in.evm.Config.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
+			in.evm.Config.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, CallErrorFromErr(err))
 			logged = true
 		}
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -158,9 +158,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		defer func() {
 			if err != nil {
 				if !logged {
-					in.evm.Config.Tracer.CaptureState(pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, CallErrorFromErr(err))
+					in.evm.Config.Tracer.CaptureState(pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
 				} else {
-					in.evm.Config.Tracer.CaptureFault(pcCopy, op, gasCopy, cost, callContext, in.evm.depth, CallErrorFromErr(err))
+					in.evm.Config.Tracer.CaptureFault(pcCopy, op, gasCopy, cost, callContext, in.evm.depth, VMErrorFromErr(err))
 				}
 			}
 		}()
@@ -219,7 +219,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			// Do tracing before memory expansion
 			if debug {
 				in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, GasChangeCallOpCode)
-				in.evm.Config.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, CallErrorFromErr(err))
+				in.evm.Config.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
 				logged = true
 			}
 			if memorySize > 0 {
@@ -227,7 +227,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			}
 		} else if debug {
 			in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, GasChangeCallOpCode)
-			in.evm.Config.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, CallErrorFromErr(err))
+			in.evm.Config.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
 			logged = true
 		}
 

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -17,8 +17,6 @@
 package vm
 
 import (
-	"errors"
-	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -46,111 +44,6 @@ type EVMLogger interface {
 	CaptureKeccakPreimage(hash common.Hash, data []byte)
 	// Misc
 	OnGasChange(old, new uint64, reason GasChangeReason)
-}
-
-type VMError struct {
-	error
-	code VMErrorCode
-}
-
-func VMErrorFromErr(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	return &VMError{
-		error: err,
-		code:  vmErrorCodeFromErr(err),
-	}
-}
-
-func (e *VMError) Error() string {
-	return e.error.Error()
-}
-
-func (e *VMError) Unwrap() error {
-	return errors.Unwrap(e.error)
-}
-
-func (e *VMError) ErrorCode() VMErrorCode {
-	return e.code
-}
-
-type VMErrorCode int
-
-const (
-	VMErrorCodeUnspecified VMErrorCode = iota
-
-	VMErrorCodeOutOfGas
-	VMErrorCodeCodeStoreOutOfGas
-	VMErrorCodeDepth
-	VMErrorCodeInsufficientBalance
-	VMErrorCodeContractAddressCollision
-	VMErrorCodeExecutionReverted
-	VMErrorCodeMaxInitCodeSizeExceeded
-	VMErrorCodeMaxCodeSizeExceeded
-	VMErrorCodeInvalidJump
-	VMErrorCodeWriteProtection
-	VMErrorCodeReturnDataOutOfBounds
-	VMErrorCodeGasUintOverflow
-	VMErrorCodeInvalidCode
-	VMErrorCodeNonceUintOverflow
-	VMErrorCodeStackUnderflow
-	VMErrorCodeStackOverflow
-	VMErrorCodeInvalidOpCode
-
-	// VMErrorCodeUnknown explicitly marks an error as unknown, this is useful when error is converted
-	// from an actual `error` in which case if the mapping is not known, we can use this value to indicate that.
-	VMErrorCodeUnknown = math.MaxInt - 1
-)
-
-func vmErrorCodeFromErr(err error) VMErrorCode {
-	switch {
-	case errors.Is(err, ErrOutOfGas):
-		return VMErrorCodeOutOfGas
-	case errors.Is(err, ErrCodeStoreOutOfGas):
-		return VMErrorCodeCodeStoreOutOfGas
-	case errors.Is(err, ErrDepth):
-		return VMErrorCodeDepth
-	case errors.Is(err, ErrInsufficientBalance):
-		return VMErrorCodeInsufficientBalance
-	case errors.Is(err, ErrContractAddressCollision):
-		return VMErrorCodeContractAddressCollision
-	case errors.Is(err, ErrExecutionReverted):
-		return VMErrorCodeExecutionReverted
-	case errors.Is(err, ErrMaxInitCodeSizeExceeded):
-		return VMErrorCodeMaxInitCodeSizeExceeded
-	case errors.Is(err, ErrMaxCodeSizeExceeded):
-		return VMErrorCodeMaxCodeSizeExceeded
-	case errors.Is(err, ErrInvalidJump):
-		return VMErrorCodeInvalidJump
-	case errors.Is(err, ErrWriteProtection):
-		return VMErrorCodeWriteProtection
-	case errors.Is(err, ErrReturnDataOutOfBounds):
-		return VMErrorCodeReturnDataOutOfBounds
-	case errors.Is(err, ErrGasUintOverflow):
-		return VMErrorCodeGasUintOverflow
-	case errors.Is(err, ErrInvalidCode):
-		return VMErrorCodeInvalidCode
-	case errors.Is(err, ErrNonceUintOverflow):
-		return VMErrorCodeNonceUintOverflow
-
-	default:
-		// Dynamic errors
-		if v := (*ErrStackUnderflow)(nil); errors.As(err, &v) {
-			return VMErrorCodeStackUnderflow
-		}
-
-		if v := (*ErrStackOverflow)(nil); errors.As(err, &v) {
-			return VMErrorCodeStackOverflow
-		}
-
-		if v := (*ErrInvalidOpCode)(nil); errors.As(err, &v) {
-			return VMErrorCodeInvalidOpCode
-		}
-
-		return VMErrorCodeUnknown
-	}
 }
 
 // GasChangeReason is used to indicate the reason for a gas change, useful


### PR DESCRIPTION
First version to open up the discussion. I added error code support with a minimal disruptive approach for now, see some PR in the code for potential alternatives.

For now I'm carrying both the original error and the attached code. I felt that having both was important (it's more true for `state_transition` error has they contain extra information data, but it's true also for some VM errors).

After a second though, I think we should not codify transaction error. My reasoning here is that those errors actually to a bad block being emitted. This means that even a live tracer should actually completely dropped the block if an error is reported in `OnBlockEnd`. I'm opening the discussion here about that, if we decide we should codify them, the current PR approach could be used.

Finally, we could also think about not adding code at all. Indeed, all errors are actual variables in the code acting as error code directly, someone could easily implement the `switch` case I have in this PR and have error properly map to a stable definition. While the error message could change, I think there will always be a way to determine what specific error happened. 

Let me know what you think about all this. Happy to jump a call tomorrow with you to discuss that.